### PR TITLE
feat(backend):implementación de JWT con login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.6.0</version>
         </dependency>
+
+        <!-- Seguridad -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
@@ -83,6 +85,28 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- JWT Tokens * -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/team2/api/AdminArticleController.java
+++ b/src/main/java/com/team2/api/AdminArticleController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/admin/articles")
+@PreAuthorize("hasAnyRole('ADMIN','CREATOR')")
 public class AdminArticleController {
     private final AdminArticleService adminArticleService;
 

--- a/src/main/java/com/team2/api/AdminCategoryController.java
+++ b/src/main/java/com/team2/api/AdminCategoryController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/admin/categories")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminCategoryController {
     private final AdminCategoryService adminCategoryService;
 

--- a/src/main/java/com/team2/api/AdminCreatorController.java
+++ b/src/main/java/com/team2/api/AdminCreatorController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/admin/creators")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')") //Se aplica la restricciones a nivel de clase
 public class AdminCreatorController {
 
     private final AdminCreatorService adminCreatorService;

--- a/src/main/java/com/team2/api/AdminPlanController.java
+++ b/src/main/java/com/team2/api/AdminPlanController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/admin/plans")
-
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminPlanController {
     private final AdminPlanService planService;
 

--- a/src/main/java/com/team2/api/AuthController.java
+++ b/src/main/java/com/team2/api/AuthController.java
@@ -1,6 +1,8 @@
 package com.team2.api;
 
 
+import com.team2.dto.user.AuthResponseDTO;
+import com.team2.dto.user.LoginDTO;
 import com.team2.dto.user.UserProfileDTO;
 import com.team2.dto.user.UserRegistrationDTO;
 import com.team2.service.UserService;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/auth")
+//No se usa el @PreAuthorize al ser un controlador publico
 public class AuthController {
 
     private final UserService userService;
@@ -29,6 +32,12 @@ public class AuthController {
     public ResponseEntity<UserProfileDTO> registerCreator(@Valid @RequestBody UserRegistrationDTO userRegistrationDTO) {
         UserProfileDTO userProfile = userService.registerCreator(userRegistrationDTO);
         return new ResponseEntity<>(userProfile, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDTO> login(@Valid @RequestBody LoginDTO loginDTO) {
+        AuthResponseDTO authResponseDTO = userService.login(loginDTO);
+        return new ResponseEntity<>(authResponseDTO, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/team2/api/CollectionArticleController.java
+++ b/src/main/java/com/team2/api/CollectionArticleController.java
@@ -7,6 +7,7 @@ import com.team2.service.CollectionArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/collections-articles")
 @RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('READER' , 'ADMIN')")
 public class CollectionArticleController {
     private final CollectionArticleService collectionArticleService;
 

--- a/src/main/java/com/team2/api/CommentController.java
+++ b/src/main/java/com/team2/api/CommentController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/comments")
-
+@PreAuthorize("hasAnyRole('ADMIN', 'CREATOR')")
 public class CommentController {
     private final CommentService commentService;
 
@@ -25,12 +26,14 @@ public class CommentController {
     }
 
     @PostMapping("/create")
+    @PreAuthorize("hasRole('READER')")
     public ResponseEntity<CommentDetailsDTO> create(@Valid @RequestBody CommentCreateDTO commentCreateDTO) {
         CommentDetailsDTO createcomment = commentService.create(commentCreateDTO);
         return new ResponseEntity<>(createcomment, HttpStatus.CREATED);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('READER')")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {
         commentService.delete(id);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/team2/api/FavoriteController.java
+++ b/src/main/java/com/team2/api/FavoriteController.java
@@ -5,6 +5,7 @@ import com.team2.service.FavoriteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -12,9 +13,9 @@ import java.util.List;
 @RestController
 @RequestMapping("/favorites")
 @RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('READER', 'ADMIN')")
 public class FavoriteController {
 
-    // asd
     private final FavoriteService favoriteService;
 
     @PostMapping

--- a/src/main/java/com/team2/api/MediaController.java
+++ b/src/main/java/com/team2/api/MediaController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,6 +17,7 @@ import java.nio.file.Files;
 @RequiredArgsConstructor
 @RequestMapping("/media")
 @RestController
+@PreAuthorize("hasAnyRole('ADMIN', 'CREATOR')")
 public class MediaController {
 
     private final StorageService storageService;

--- a/src/main/java/com/team2/api/UserProfileController.java
+++ b/src/main/java/com/team2/api/UserProfileController.java
@@ -6,12 +6,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/user/profile")
+@PreAuthorize("hasAnyRole('READER', 'CREATOR')")
 public class UserProfileController {
+
     private final UserService userService;
 
     //Actualizar perfil de usuario

--- a/src/main/java/com/team2/config/SwaggerAPIConfig.java
+++ b/src/main/java/com/team2/config/SwaggerAPIConfig.java
@@ -1,14 +1,19 @@
 package com.team2.config;
 
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerAPIConfig {
@@ -40,9 +45,23 @@ public class SwaggerAPIConfig {
                 .termsOfService("https://github.com/ReadEDU/readedu-api")
                 .license(mitLicense);
 
+        // Configuración de seguridad JWT
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name("JWT Authentication");
+
+        Components components = new Components()
+                .addSecuritySchemes("bearerAuth", securityScheme);
+
+        // Requerimiento de seguridad para utilizar en las operaciones
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
         return new OpenAPI()
                 .info(info)
-                .addServersItem(devServer);
-
+                .servers(List.of(devServer))
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 }

--- a/src/main/java/com/team2/config/WebSecurityConfig.java
+++ b/src/main/java/com/team2/config/WebSecurityConfig.java
@@ -1,27 +1,76 @@
 package com.team2.config;
 
+import com.team2.security.JWTConfigurer;
+import com.team2.security.JWTFilter;
+import com.team2.security.JwtAuthenticationEntryPoint;
+import com.team2.security.TokenProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+@RequiredArgsConstructor
 @Configuration
+@EnableWebSecurity
+@EnableMethodSecurity //Activa las notaciones @PreAuthorize
 public class WebSecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final JWTFilter jwtRequestFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final UserDetailsService userDetailsService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(
-                        auth->auth.anyRequest().permitAll()
-                );
+        http
+                .cors(Customizer.withDefaults()) // Habilitar CORS
+                .csrf(AbstractHttpConfigurer::disable) // Deshabilitar CSRF en APIs REST
+
+                .authorizeHttpRequests(authorize -> authorize
+                        // Permitir acceso a los endpoints de registro y login sin autenticación
+                        .requestMatchers(antMatcher("/auth/login")).permitAll()
+                        .requestMatchers(antMatcher("/auth/register/reader")).permitAll()
+                        .requestMatchers(antMatcher("/auth/register/creator")).permitAll()
+                        //.requestMatchers(antMatcher("/article/recent")).permitAll()
+
+                        .requestMatchers("/api/v1/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/webjars/**").permitAll()
+                        // Cualquier otra solicitud requiere autenticación
+                        .anyRequest().authenticated()
+                )
+                //.httpBasic(Customizer.withDefaults())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .sessionManagement(h -> h.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .with(new JWTConfigurer(tokenProvider), Customizer.withDefaults());
+        //.httpBasic(Customizer.withDefaults()); // Utilizar autenticación básica HTTP para pruebas con Postman
+
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/team2/dto/user/AuthResponseDTO.java
+++ b/src/main/java/com/team2/dto/user/AuthResponseDTO.java
@@ -1,0 +1,11 @@
+package com.team2.dto.user;
+
+import lombok.Data;
+
+@Data
+public class AuthResponseDTO {
+    private String token; //Token JWT
+    private String firstName; //Nombre
+    private String lastName; //Apellido
+    private String role; //Rol
+}

--- a/src/main/java/com/team2/dto/user/LoginDTO.java
+++ b/src/main/java/com/team2/dto/user/LoginDTO.java
@@ -1,0 +1,15 @@
+package com.team2.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginDTO {
+    @NotBlank(message = "El email es obligatorio")
+    @Email(message = "El email  no es válido")
+    private String email;
+
+    @NotBlank(message = "La contraseña es obligatoria")
+    private String password;
+}

--- a/src/main/java/com/team2/mapper/UserMapper.java
+++ b/src/main/java/com/team2/mapper/UserMapper.java
@@ -1,5 +1,7 @@
 package com.team2.mapper;
 
+import com.team2.dto.user.AuthResponseDTO;
+import com.team2.dto.user.LoginDTO;
 import com.team2.dto.user.UserProfileDTO;
 import com.team2.dto.user.UserRegistrationDTO;
 import com.team2.model.entity.User;
@@ -32,5 +34,29 @@ public class UserMapper {
             }
 
             return userProfileDTO;
+    }
+
+    public User toUserEntity(LoginDTO loginDTO) {
+        return modelMapper.map(loginDTO, User.class);
+    }
+
+    public AuthResponseDTO toAuthResponseDTO(User user, String token) {
+        AuthResponseDTO authResponseDTO = new AuthResponseDTO();
+        authResponseDTO.setToken(token);
+
+        // Obtener el nombre y apellido
+        String firstName = (user.getReader() != null) ? user.getReader().getFirstName()
+                : (user.getCreator() != null) ? user.getCreator().getFirstName()
+                : "Admin";
+        String lastName = (user.getReader() != null) ? user.getReader().getLastName()
+                : (user.getCreator() != null) ? user.getCreator().getLastName()
+                : "User";
+
+        authResponseDTO.setFirstName(firstName);
+        authResponseDTO.setLastName(lastName);
+
+        authResponseDTO.setRole(user.getRole().getName().name());
+
+        return authResponseDTO;
     }
 }

--- a/src/main/java/com/team2/repository/RoleRepository.java
+++ b/src/main/java/com/team2/repository/RoleRepository.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface RoleRepository extends JpaRepository<Role, Integer> {
-
     //Metodo para buscar un usuario por email (sera usado en la autenticacion)
     Optional<Role> findByName(ERole name);
 }

--- a/src/main/java/com/team2/security/CustomUserDetailsService.java
+++ b/src/main/java/com/team2/security/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.team2.security;
+
+import com.team2.model.entity.User;
+import com.team2.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado con el email: " + email));
+
+        GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + user.getRole().getName().name());
+
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                Collections.singletonList(authority),
+                user
+        );
+    }
+}

--- a/src/main/java/com/team2/security/JWTConfigurer.java
+++ b/src/main/java/com/team2/security/JWTConfigurer.java
@@ -1,0 +1,18 @@
+package com.team2.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JWTConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        JWTFilter jwtFilter = new JWTFilter(tokenProvider);
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/team2/security/JWTFilter.java
+++ b/src/main/java/com/team2/security/JWTFilter.java
@@ -1,0 +1,36 @@
+package com.team2.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class JWTFilter extends GenericFilterBean {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String bearerToken = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/team2/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/team2/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package com.team2.security;
+
+import com.team2.exception.CustomErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+
+        String exceptionMsg = (String) request.getAttribute("exception");
+
+        if (exceptionMsg == null) {
+            exceptionMsg = "Token not found";
+        }
+
+        CustomErrorResponse errorResponse = new CustomErrorResponse(LocalDateTime.now(), exceptionMsg, request.getRequestURI());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(convertObjectToJson(errorResponse));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    private String convertObjectToJson(Object object) throws JsonProcessingException {
+        if (object == null) {
+            return null;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        return mapper.writeValueAsString(object);
+    }
+}

--- a/src/main/java/com/team2/security/TokenProvider.java
+++ b/src/main/java/com/team2/security/TokenProvider.java
@@ -1,0 +1,77 @@
+package com.team2.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class TokenProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.validity-in-seconds}")
+    private long jwtValidityInSeconds;
+
+    private Key key;
+    private JwtParser jwtParser;
+
+    @PostConstruct
+    public void init() {
+        key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret));
+        jwtParser = Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build();
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        String email = authentication.getName();
+        String role = authentication
+                .getAuthorities()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No se encontró un rol para el usuario"))
+                .getAuthority();
+
+        return Jwts
+                .builder()
+                .setSubject(email)
+                .claim("role", role)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .setExpiration(new Date(System.currentTimeMillis() + jwtValidityInSeconds * 1000))
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = jwtParser.parseClaimsJws(token).getBody();
+        String role = claims.get("role").toString();
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
+        User principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try{
+            jwtParser.parseClaimsJws(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/team2/security/UserPrincipal.java
+++ b/src/main/java/com/team2/security/UserPrincipal.java
@@ -1,0 +1,36 @@
+package com.team2.security;
+
+import com.team2.model.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserPrincipal implements UserDetails {
+    private Integer id;
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/com/team2/service/UserService.java
+++ b/src/main/java/com/team2/service/UserService.java
@@ -1,5 +1,7 @@
 package com.team2.service;
 
+import com.team2.dto.user.AuthResponseDTO;
+import com.team2.dto.user.LoginDTO;
 import com.team2.dto.user.UserProfileDTO;
 import com.team2.dto.user.UserRegistrationDTO;
 
@@ -8,6 +10,8 @@ public interface UserService {
     UserProfileDTO registerReader(UserRegistrationDTO registrationDTO);
 
     UserProfileDTO registerCreator(UserRegistrationDTO registrationDTO);
+
+    AuthResponseDTO login(LoginDTO loginDTO);
 
     UserProfileDTO updateUserProfile(Integer id, UserProfileDTO userProfileDTO);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,11 +10,17 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 # Propiedades de JPA/Hibernate
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
+
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.sql.init.mode=always
 spring.sql.init.data-locations=classpath:data-test.sql
+
+# Clave secreta utilizada para firmar y verificar los tokens JWT. Debe mantenerse segura.
+jwt.secret=chLhMF9w3mwDutysbQxsX8x4CGwZef4mayTGSmbAG2BUsXbYFKvXrVfnPCa62PJxp9TuHxx4PQAS2yGUTBAPy3Dy53j8Uj2wb2AQ3nK8VLg7tUx9HCzHATEp
+# Tiempo de validez de los tokens JWT en segundos (30 dias).
+jwt.validity-in-seconds=2592000
 
 readedu.openapi.dev-url=http://localhost:8080/api/v1
 


### PR DESCRIPTION
En este pull request hice implementaciones de las HUs de login/autenticación con roles.

###Cambios Realizados
-Se modifico el AuthController con implementación de Post en login
-Se modifico la clase "UserServiceImpl".
-Se crearon 6 clases nuevas en una carpeta llamada "Security" con los siguientes nombres:

      1. CustomUserDetailsService
      2. JwtAuthtenticationEntryPoint
      3. JWTConfigurer
      4. JWTFiltrer
      5. TokenProvider
      6. UserPrincipal
      
Además se agregó SecurityFilterChain en "WebSecurityConfig".
-Se implementó @PreAuthorize en todos los controladores existentes de momento.

      1. AdminArticleController (Admin) (Creator)
      2. AdminCategoryController  (Admin)
      3. AdminCreatorController  (Admin)
      4. AdminPlanController (Admin)
      5. AuthController //No tiene roles 
      6. CollectionArticleController (Reader) (Admin)
      8. CommentController (Admin) (Creator) //En  POST y Delete (Reader)
      9. FavoriteController (Reader) (Admin)
      10. MediaController (Admin) (Creator)
     11. UserProfileController (Reader) (Creator)

###Adicional
-Se hizo cambios en SwaggerAPIConfig para el Authorize.
-Se comprobó la autenticación en Postman.

//Para probar el rol de "Admin" se hizo un cambio desde la base de datos con un usuario existente, por el momento todavía no se usará una cuenta administrador para la TA2.