### PR TITLE
feat(backend): implementación de envió de correo para recuperar contraseña y confirmar pago

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,20 @@
             <version>0.11.5</version>
             <scope>runtime</scope>
         </dependency>
-
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
             <version>0.11.5</version>
             <scope>runtime</scope>
+        </dependency>
+        <!-- Para correos -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/team2/api/CheckoutController.java
+++ b/src/main/java/com/team2/api/CheckoutController.java
@@ -3,6 +3,7 @@ package com.team2.api;
 import com.team2.dto.payments.PaymentCaptureResponse;
 import com.team2.dto.payments.PaymentOrderResponse;
 import com.team2.service.CheckoutService;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class CheckoutController {
             @RequestParam String returnUrl,
             @RequestParam String cancelUrl,
             @RequestParam(required = false, defaultValue = "paypal") String paymentProvider
-    ) {
+    ) throws MessagingException {
         PaymentOrderResponse response = checkoutService.createPayment(purchaseId, returnUrl, cancelUrl);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
@@ -34,7 +35,7 @@ public class CheckoutController {
     public ResponseEntity<PaymentCaptureResponse> capturePaymentOrder(
             @RequestParam String orderId,
             @RequestParam(required = false, defaultValue = "paypal") String paymentProvider
-    ) {
+    ) throws MessagingException {
         PaymentCaptureResponse response = checkoutService.capturePayment(orderId);
 
         if (response.isCompleted()) {

--- a/src/main/java/com/team2/api/MailController.java
+++ b/src/main/java/com/team2/api/MailController.java
@@ -1,0 +1,36 @@
+package com.team2.api;
+
+import com.team2.service.PasswordResetTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/mail")
+@RequiredArgsConstructor
+public class MailController {
+
+    private final PasswordResetTokenService passwordResetTokenService;
+
+    //Enviar email para reestablecer la contraseña
+    @PostMapping("/sendMail")
+    public ResponseEntity<Void> sendPasswordResetMail(@RequestBody String email) throws Exception {
+        passwordResetTokenService.createAndSendPasswordResetToken(email);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    //Comprobar la validez del token para recuperar la contraseña
+    @GetMapping("/reset/check/{token}")
+    public ResponseEntity<Boolean> checkTokenValidity(@PathVariable("token") String token) {
+        boolean isValid = passwordResetTokenService.isValidToken(token);
+        return new ResponseEntity<>(isValid, HttpStatus.OK);
+    }
+
+    // Restablecer la contraseña usando el token
+    @PostMapping("/reset/{token}")
+    public ResponseEntity<Void> resetPassword(@PathVariable("token") String token, @RequestBody String newPassword) {
+        passwordResetTokenService.resetPassword(token, newPassword);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/team2/config/WebSecurityConfig.java
+++ b/src/main/java/com/team2/config/WebSecurityConfig.java
@@ -50,6 +50,7 @@ public class WebSecurityConfig {
                         .requestMatchers(antMatcher("/auth/login")).permitAll()
                         .requestMatchers(antMatcher("/auth/register/reader")).permitAll()
                         .requestMatchers(antMatcher("/auth/register/creator")).permitAll()
+                        .requestMatchers(antMatcher("/mail/**")).permitAll()
                         //.requestMatchers(antMatcher("/article/recent")).permitAll()
 
                         .requestMatchers("/api/v1/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/webjars/**").permitAll()

--- a/src/main/java/com/team2/integration/notification/email/dto/Mail.java
+++ b/src/main/java/com/team2/integration/notification/email/dto/Mail.java
@@ -1,0 +1,17 @@
+package com.team2.integration.notification.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Mail {
+    private String from; //Para el remitente
+    private String to; //Para el destinatario
+    private String subject; //Asunto del correo
+    private Map<String, Object> model; //Modelo de datos para la plantilla
+}

--- a/src/main/java/com/team2/integration/notification/email/service/EmailService.java
+++ b/src/main/java/com/team2/integration/notification/email/service/EmailService.java
@@ -1,0 +1,48 @@
+package com.team2.integration.notification.email.service;
+
+import com.team2.integration.notification.email.dto.Mail;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    public Mail createMail(String to, String subject, Map<String, Object> model, String from) {
+        Mail mail = new Mail();
+        mail.setFrom(from);
+        mail.setTo(to);
+        mail.setSubject(subject);
+        mail.setModel(model);
+        return mail;
+    }
+
+    public void sendEMail(Mail mail, String templateName) throws MessagingException {
+
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message,
+                MimeMessageHelper.MULTIPART_MODE_MIXED_RELATED, "UTF-8");
+
+        Context context = new Context();
+        context.setVariables(mail.getModel());
+
+        String html = templateEngine.process(templateName, context);
+        helper.setTo(mail.getTo());
+        helper.setText(html, true);
+        helper.setSubject(mail.getSubject());
+        helper.setFrom(mail.getFrom());
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/team2/model/entity/PasswordResetToken.java
+++ b/src/main/java/com/team2/model/entity/PasswordResetToken.java
@@ -1,0 +1,42 @@
+package com.team2.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class PasswordResetToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @Size(min = 32, max = 64)
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDateTime expiration;
+
+    @NotNull
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public void setExpiration(int minutes) {
+        this.expiration = LocalDateTime.now().plusMinutes(minutes);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiration);
+    }
+}

--- a/src/main/java/com/team2/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/team2/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.team2.repository;
+
+import com.team2.model.entity.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Integer> {
+    Optional<PasswordResetToken> findByToken(String token);
+}

--- a/src/main/java/com/team2/service/CheckoutService.java
+++ b/src/main/java/com/team2/service/CheckoutService.java
@@ -2,8 +2,9 @@ package com.team2.service;
 
 import com.team2.dto.payments.PaymentCaptureResponse;
 import com.team2.dto.payments.PaymentOrderResponse;
+import jakarta.mail.MessagingException;
 
 public interface CheckoutService {
-    PaymentOrderResponse createPayment(Integer purchaseId, String returnUrl, String cancelUrl);
-    PaymentCaptureResponse capturePayment(String orderId);
+    PaymentOrderResponse createPayment(Integer purchaseId, String returnUrl, String cancelUrl)throws MessagingException;
+    PaymentCaptureResponse capturePayment(String orderId) throws MessagingException;
 }

--- a/src/main/java/com/team2/service/PasswordResetTokenService.java
+++ b/src/main/java/com/team2/service/PasswordResetTokenService.java
@@ -1,0 +1,11 @@
+package com.team2.service;
+
+import com.team2.model.entity.PasswordResetToken;
+
+public interface PasswordResetTokenService {
+    void createAndSendPasswordResetToken(String email) throws Exception;
+    PasswordResetToken findByToken(String token);
+    void removePasswordResetToken(PasswordResetToken passwordResetToken);
+    boolean isValidToken(String token);
+    void resetPassword(String token, String newPassword);
+}

--- a/src/main/java/com/team2/service/impl/CheckoutServiceImpl.java
+++ b/src/main/java/com/team2/service/impl/CheckoutServiceImpl.java
@@ -3,19 +3,33 @@ package com.team2.service.impl;
 import com.team2.dto.payments.PaymentCaptureResponse;
 import com.team2.dto.payments.PaymentOrderResponse;
 import com.team2.dto.purchase.PurchaseDTO;
+import com.team2.integration.notification.email.dto.Mail;
+import com.team2.integration.notification.email.service.EmailService;
 import com.team2.integration.payment.paypal.dto.OrderCaptureResponse;
 import com.team2.integration.payment.paypal.dto.OrderResponse;
 import com.team2.integration.payment.paypal.service.PayPalService;
 import com.team2.service.CheckoutService;
 import com.team2.service.PurchaseService;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
 public class CheckoutServiceImpl implements CheckoutService {
+
     private final PayPalService paypalService;
     private final PurchaseService purchaseService;
+    private final EmailService emailService;
+
+    @Value("${spring.mail.username")
+    private String mailFrom;
 
     @Override
     public PaymentOrderResponse createPayment(Integer purchaseId, String returnUrl, String cancelUrl) {
@@ -33,7 +47,7 @@ public class CheckoutServiceImpl implements CheckoutService {
     }
 
     @Override
-    public PaymentCaptureResponse capturePayment(String orderId) {
+    public PaymentCaptureResponse capturePayment(String orderId) throws MessagingException {
         OrderCaptureResponse orderCaptureResponse = paypalService.captureOrder(orderId);
         boolean completed = orderCaptureResponse.getStatus().equals("COMPLETED");
 
@@ -44,8 +58,29 @@ public class CheckoutServiceImpl implements CheckoutService {
             String purchaseIdStr = orderCaptureResponse.getPurchaseUnits().get(0).getReferenceId();
             PurchaseDTO purchaseDTO = purchaseService.confirmPurchase(Integer.parseInt(purchaseIdStr));
             paypalCaptureResponse.setPurchaseId(purchaseDTO.getId());
+
+            sendPurchaseConfirmationEmail(purchaseDTO);
         }
 
         return paypalCaptureResponse;
+    }
+
+    private void sendPurchaseConfirmationEmail(PurchaseDTO purchaseDTO) throws MessagingException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmail = authentication.getName();
+
+        Map<String, Object> model = new HashMap<>();
+        model.put("user", userEmail);
+        model.put("total", purchaseDTO.getTotal());
+        model.put("orderUrl", "http://localhost:4200/order/" + purchaseDTO.getId());
+
+        Mail mail = emailService.createMail(
+                userEmail,
+                "Confirmación de Pago",
+                model,
+                mailFrom
+        );
+        emailService.sendEMail(mail, "email/purchase-confirmation-template");
     }
 }

--- a/src/main/java/com/team2/service/impl/PasswordResetTokenServiceImpl.java
+++ b/src/main/java/com/team2/service/impl/PasswordResetTokenServiceImpl.java
@@ -1,0 +1,88 @@
+package com.team2.service.impl;
+
+import com.team2.exception.ResourceNotFoundException;
+import com.team2.integration.notification.email.dto.Mail;
+import com.team2.integration.notification.email.service.EmailService;
+import com.team2.model.entity.PasswordResetToken;
+import com.team2.model.entity.User;
+import com.team2.repository.PasswordResetTokenRepository;
+import com.team2.repository.UserRepository;
+import com.team2.service.PasswordResetTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetTokenServiceImpl implements PasswordResetTokenService {
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${spring.mail.username")
+    private String mailFrom;
+
+    @Transactional
+    @Override
+    public void createAndSendPasswordResetToken(String email) throws Exception {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado con email: " + email));
+
+        PasswordResetToken passwordResetToken = new PasswordResetToken();
+        passwordResetToken.setToken(UUID.randomUUID().toString());
+        passwordResetToken.setUser(user);
+        passwordResetToken.setExpiration(10);
+        passwordResetTokenRepository.save(passwordResetToken);
+
+        Map<String, Object> model =new HashMap<>();
+        String resetUrl = "http://localhost:4200/#/forgot/" + passwordResetToken.getToken();
+        model.put("user", user.getEmail());
+        model.put("resetUrl", resetUrl);
+
+        Mail mail = emailService.createMail(
+                user.getEmail(),
+                "Restablecer Contraseña",
+                model,
+                mailFrom
+        );
+
+        emailService.sendEMail(mail,"email/password-reset-template");
+    }
+
+    @Override
+    public PasswordResetToken findByToken(String token) {
+        return passwordResetTokenRepository.findByToken(token)
+                .orElseThrow(() -> new ResourceNotFoundException("Token no encontrado"));
+    }
+
+    @Override
+    public void removePasswordResetToken(PasswordResetToken passwordResetToken) {
+        passwordResetTokenRepository.delete(passwordResetToken);
+    }
+
+    @Override
+    public boolean isValidToken(String token) {
+        return passwordResetTokenRepository.findByToken(token)
+                .filter(t->!t.isExpired())
+                .isPresent();
+    }
+
+    @Override
+    public void resetPassword(String token, String newPassword) {
+        PasswordResetToken resetToken = passwordResetTokenRepository.findByToken(token)
+                .filter(t->!t.isExpired())
+                .orElseThrow(() -> new ResourceNotFoundException("Token no invalido o expirado"));
+
+        User user = resetToken.getUser();
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+        passwordResetTokenRepository.delete(resetToken);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.sql.init.mode=always
-spring.sql.init.data-locations=classpath:data-test.sql
+#spring.sql.init.data-locations=classpath:data-test.sql
 
 # Clave secreta utilizada para firmar y verificar los tokens JWT. Debe mantenerse segura.
 jwt.secret=chLhMF9w3mwDutysbQxsX8x4CGwZef4mayTGSmbAG2BUsXbYFKvXrVfnPCa62PJxp9TuHxx4PQAS2yGUTBAPy3Dy53j8Uj2wb2AQ3nK8VLg7tUx9HCzHATEp

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  mail:
+    default-encoding: UTF-8
+    host: smtp.gmail.com
+    username: readedupao@gmail.com
+    password: dwjq whaj vxug ktqu
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+    protocol: smtp
+    test-connection: false

--- a/src/main/resources/templates/email/password-reset-template.html
+++ b/src/main/resources/templates/email/password-reset-template.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Restablecimiento de Contraseña</title>
+    <style>
+        /* Global Styles */
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            color: #323f59;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            width: 80%;
+            max-width: 600px;
+            margin: 20px auto;
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        /* Header and Footer */
+        header {
+            background-color: #99cc66; /* Verde claro */
+            color: #000000; /* Negro */
+            text-align: center;
+            padding: 10px;
+            border-radius: 8px 8px 0 0;
+        }
+        h1 {
+            margin: 0;
+            font-size: 24px;
+            font-weight: bold;
+        }
+
+        /* Content Styles */
+        p {
+            font-size: 16px;
+            margin: 15px 0;
+            text-align: left;
+            color: #333333;
+        }
+
+        .button-container {
+            text-align: center;
+            margin: 20px 0;
+        }
+
+        .button {
+            background-color: #4caf50; /* Verde botón */
+            color: white;
+            padding: 15px 30px;
+            text-decoration: none;
+            border-radius: 5px;
+            font-size: 18px;
+            font-weight: bold;
+            display: inline-block;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            transition: background-color 0.3s ease;
+        }
+
+        .button:hover {
+            background-color: #388e3c;
+        }
+
+        /* Footer Styles */
+        footer {
+            background-color: #99cc66; /* Verde claro */
+            padding: 10px;
+            border-radius: 0 0 8px 8px;
+            text-align: center; /* Centrado */
+        }
+
+        .footer-text {
+            font-size: 14px;
+            color: #333333;
+            margin: 0;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <!-- Header -->
+    <header>
+        <h1>Restablecimiento de Contraseña</h1>
+    </header>
+
+    <!-- Content -->
+    <p>Hola <span th:text="${user}">Usuario</span>,</p>
+    <p>Hemos recibido una solicitud para restablecer tu contraseña. Si no solicitaste este cambio, puedes ignorar este mensaje.</p>
+    <p>Para restablecer tu contraseña, haz clic en el siguiente botón:</p>
+
+    <!-- Button -->
+    <div class="button-container">
+        <a th:href="${resetUrl}" class="button">Restablecer Contraseña</a>
+    </div>
+
+    <p>Este enlace será válido por 24 horas.</p>
+    <p>El equipo de ReadEDU</p>
+
+    <!-- Footer -->
+    <footer>
+        <p class="footer-text">&copy; 2024 ReadEDU</p>
+    </footer>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email/purchase-confirmation-template.html
+++ b/src/main/resources/templates/email/purchase-confirmation-template.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Confirmación de Donación</title>
+  <style>
+    /* GLOBAL STYLES */
+    body {
+      background-color: #f6f6f6;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      font-size: 14px;
+      line-height: 1.4;
+      -webkit-font-smoothing: antialiased;
+    }
+    .body {
+      background-color: #f6f6f6;
+      width: 100%;
+    }
+    .container {
+      display: block;
+      max-width: 580px;
+      padding: 10px;
+      margin: 0 auto;
+    }
+    .content {
+      max-width: 580px;
+      padding: 20px;
+      background-color: #ffffff;
+      border-radius: 5px;
+    }
+
+    /* HEADER STYLES */
+    h1 {
+      font-size: 28px;
+      color: #333333;
+      text-align: center;
+      background-color: #99cc66; /* Verde claro */
+      padding: 15px;
+      border-radius: 5px 5px 0 0;
+    }
+    p {
+      font-size: 14px;
+      margin: 0 0 15px;
+    }
+    a {
+      color: #3498db;
+      text-decoration: none;
+    }
+
+    /* BUTTON STYLES */
+    .btn-primary {
+      text-align: center;
+      margin-top: 20px;
+    }
+    .btn-primary a {
+      display: inline-block;
+      padding: 12px 25px;
+      background-color: #4caf50; /* Verde oscuro */
+      color: #ffffff;
+      border-radius: 5px;
+      font-size: 14px;
+      font-weight: bold;
+    }
+    .btn-primary a:hover {
+      background-color: #388e3c;
+    }
+
+    /* SPACING BELOW BUTTON */
+    .message {
+      margin-top: 30px; /* Espaciado ajustado */
+    }
+
+    /* FOOTER STYLES */
+    .footer {
+      text-align: center;
+      margin-top: 20px;
+      font-size: 12px;
+      color: #999999;
+    }
+    .footer a {
+      color: #999999;
+    }
+
+    /* RESPONSIVE STYLES */
+    @media only screen and (max-width: 620px) {
+      .container {
+        width: 100% !important;
+        padding: 0 !important;
+      }
+      .content {
+        padding: 10px !important;
+      }
+      h1 {
+        font-size: 24px !important;
+      }
+      .btn-primary a {
+        width: 100% !important;
+      }
+    }
+  </style>
+</head>
+<body>
+<table role="presentation" class="body">
+  <tr>
+    <td>&nbsp;</td>
+    <td class="container">
+      <div class="content">
+
+        <!-- Header -->
+        <h1>¡Gracias por tu donación!</h1>
+        <p>Hola lector,<span th:text="${user}"></span></p>
+        <p>Tu donación ha sido confirmada. Aquí tienes los detalles:</p>
+
+        <!-- Donation Details -->
+        <p><strong>Total de la donación:</strong> S/.<span th:text="${total}"></span></p>
+
+        <!-- Button to View Donation Details -->
+        <div class="btn-primary">
+          <a th:href="${orderUrl}">Ver Detalles de lo Donado</a>
+        </div>
+
+        <!-- Message Below Button -->
+        <div class="message">
+          <p>Gracias por ayudar a un creador de contenido para que siga adelante con su meta.</p>
+          <p>Atentamente,<br/> El equipo de ReadEDU</p>
+        </div>
+
+        <!-- Footer -->
+        <div class="footer">
+          <p>Trujillo, Perú</p>
+          <p>
+            <a href="http://htmlemail.io">© 2024 ReadEDU</a>
+          </p>
+        </div>
+
+      </div>
+    </td>
+    <td>&nbsp;</td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
En este pull request se realizó la implementación envió de correo para recuperar contraseña y confirmar pago

Cambios realizados:
Se agrego la entidad: "PasswordResetToken".

-En la carpeta de "integration" se agregaron las clases:
  1. Mail (DTO)
  2. EmailService (Service)

-Se implementaron las clases: "PasswordResetTokenRepository",  "PasswordResetTokenService" y ""PasswordResetTokenServiceImpl". Y este tiene un controller llamado "MailController donde se ubican los endpoints de enviar email y restablecer contraseña usando el token.

-Se modificaron las clases en "CheckoutService" , "CheckoutServiceImpl" y "CheckoutController".
-Se agrego en la carpeta Resources un directorio llamado "templates.email" los cuales contienen las plantillas para resetear contraseña y confirmar un pago de archivo HTML. Además en la misma carpeta Resources se agrego "application.yml" para poner el gmail de nuestra organización.

-Por ultimo se hizo un cambio en WebSecurityConfig para que nos deje enviar correos mediante Postman.
".requestMatchers(antMatcher("/mail/**")).permitAll()".